### PR TITLE
Create LazyInitializerWithDisposer

### DIFF
--- a/src/main/java/org/apache/commons/lang3/concurrent/AlreadyDisposedException.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/AlreadyDisposedException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.concurrent;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * An exception class used by LazyInitializerWithDisposer if get() is called after close() or dispose() .
+ *
+ * <p>
+ * The purpose of this exception class is to allow the developer to be sure an exception was caused
+ * by a {@link LazyInitializerWithDisposer}, being closed or disposed, and not from an error in the
+ * process of creating or disposing of the wrapped object.
+ * </p>
+ *
+ * @since 3.14.0
+ */
+public class AlreadyDisposedException extends ConcurrentException {
+    /**
+     * The serial version UID.
+     */
+    private static final long serialVersionUID = 6622707671812226131L;
+}

--- a/src/main/java/org/apache/commons/lang3/concurrent/LazyInitializerWithDisposer.java
+++ b/src/main/java/org/apache/commons/lang3/concurrent/LazyInitializerWithDisposer.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.concurrent;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.Optional;
+
+import org.apache.commons.lang3.function.FailableConsumer;
+import org.apache.commons.lang3.function.FailableSupplier;
+
+/**
+ * This class provides a generic implementation of the lazy initialization
+ * pattern and also contains a way to dispose of the wrapped object if it has
+ * been previously created by using a supplier and a consumer respectively.
+ * To ensure the supplier and disposer are only used once each this class 
+ * uses the double-check idiom for an instance field as discussed in  Joshua 
+ * Bloch's "Effective Java", 2nd edition, item 71. 
+ *
+ * <p>
+ * Sometimes an application has to deal with an object only under certain
+ * circumstances, e.g. when the user selects a specific menu item or if a
+ * special event is received. If the creation of the object is costly or the
+ * consumption of memory or other system resources is significant, it may make
+ * sense to defer the creation of this object until it is really needed. This is
+ * a use case for the lazy initialization pattern.
+ * </p>
+ *
+ * <p>
+ * If these objects must be disposed of, it would not make sense to create them
+ * just so they can be disposed of. Therefore this class provides the ability to
+ * dispose of objects if and only if they have been created.
+ * </p>
+ *
+ * <p>
+ * Access to the data object is provided through the {@code get()} method. and
+ * the data object is disposed with the {@code dispose()} So, code that obtains
+ * and eventually disposes of the {@code ComplexObject} instance would simply look
+ * like this:
+ * </p>
+ *
+ * <pre>
+ * // Create the supplier and disposer: 
+ * Supplier<ComplexObject> initializer = () -> new ComplexObject();
+ * Consumer<ComplexObject> disposer = complexObject -> complexObject.shutDown();
+ *
+ * // Create an instance of the lazy initializer
+ * ComplexObjectInitializer initializer = new ComplexObjectInitializer(initializer, disposer);
+ * ...
+ * // When the object is actually needed:
+ * ComplexObject cobj = initializer.get();
+ * 
+ * // When it is time to dispose of the object
+ * initializer.dispose();
+ * </pre>
+ *
+ * <p>
+ * If multiple threads call the {@code get()} method when the object has not yet
+ * been created, they are blocked until initialization completes. The algorithm
+ * guarantees that only a single instance of the wrapped object class is
+ * created, which is passed to all callers. Once initialized, calls to the
+ * {@code get()} method are pretty fast because no synchronization is needed
+ * (only an access to a <b>volatile</b> member field).
+ * </p>
+ *
+ * @since 3.14.0
+ * @param <T> the type of the object managed by this initializer class
+ */
+public class LazyInitializerWithDisposer<T> implements ConcurrentInitializer<T> {
+
+    //NO_INIT serves double duty as the lock object to prevent any other class acquiring the monitor
+    private final Object NO_INIT = new Object(){};
+    private final Object DISPOSED = new Object(){};
+
+    private FailableConsumer<? super T, ? extends Exception> disposer;
+    private FailableSupplier<? extends T, ? extends Exception> initializer;
+
+    // Stores the managed object.
+    private volatile T object = (T) NO_INIT;
+
+    private int allowedTries;
+    Exception firstFailure = null;
+
+    /** 
+     * Constructs a LazyInitializerWithDisposer with a given initializer and disposer
+     *
+     * @param initializer an implimentation of the FailableSupplier functional interface which will create the wrapped object
+     * @param disposer an implimentation of the FailableConsumer functional interface which will dispose of the wrapped object
+     * @param allowedTries how many calls to get() will be allowed to attempt to initialize in total, before a failure is cached and becomes persistent. Set to a negative number for infinite retries.
+     */
+    public LazyInitializerWithDisposer(FailableSupplier<? extends T, ? extends Exception> initializer, FailableConsumer<? super T, ? extends Exception> disposer, int allowedTries) {
+        if (allowedTries == 0) {
+           throw new IllegalArgumentException("allowedTries must be a positive or negative number");
+        }
+        this.allowedTries = allowedTries;
+
+        this.initializer = initializer;
+        this.disposer = disposer;
+    }
+
+    /** 
+     * Constructs a LazyInitializerWithDisposer wtih a given initializer and disposer
+     *
+     * @param initializer an implimentation of the FailableSupplier functional interface which will create the wrapped object
+     * @param disposer an implimentation of the FailableConsumer functional interface which will dispose of the wrapped object
+     */
+    public LazyInitializerWithDisposer(FailableSupplier<? extends T, ? extends Exception> initializer, FailableConsumer<? super T, ? extends Exception> disposer) {
+        this(initializer, disposer, 4);
+    }
+
+    /**
+     * Returns the object wrapped by this instance. On first access the object
+     * is created. After that it is cached and can be accessed pretty fast.
+     *
+     * @return the object initialized by this {@link LazyInitializer}
+     * @throws ConcurrentException if an error occurred during initialization of
+     * the object. Or enough previous errors have occurred to use up all allowed tries.
+     * @throws AlreadyDisposedException if dispose() or close() has already been called.
+     */
+    @Override
+    public T get() throws ConcurrentException {
+        return getInternal();
+    }
+
+    /**
+     * Returns the object wrapped by this instance inside an Optional. On first access
+     * the object is created. After that it is cached and can be accessed pretty fast.
+     *
+     * @return an Optional wrapping object initialized by this {@link LazyInitializer}
+     * or an empty Optional if dispose() or close() has already been called.
+     * @throws ConcurrentException if an error occurred during initialization of
+     * the object. Or enough previous errors have occurred to use up all allowed tries.
+     */
+    public Optional<T> getIfPossible() throws ConcurrentException {
+        try {
+            return Optional.ofNullable(getInternal());
+        } catch (AlreadyDisposedException e) {
+            return Optional.empty();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private T getInternal() throws ConcurrentException {
+        // use a temporary variable to reduce the number of reads of the
+        // volatile field
+        T result = object;
+
+        if (result == DISPOSED) {
+            throw new AlreadyDisposedException();
+        }
+
+        if (result == NO_INIT) {
+            synchronized (NO_INIT) {
+                result = object;
+
+                if (result == DISPOSED) {
+                    throw new AlreadyDisposedException();
+                }
+
+                if (result == NO_INIT) {
+                    if (allowedTries == 0) {
+                        this.initializer = null;
+                        ConcurrentException ce = new ConcurrentException();
+                        ce.addSuppressed(firstFailure);
+                        throw ce;
+                    } else if (allowedTries > 0) {
+                        allowedTries --;
+                    }
+
+                    try {
+                        object = result = initializer.get();
+                        this.initializer = null;
+                    } catch (RuntimeException e) {//So it doesn't get wrapped in the next block.
+                        if (firstFailure == null) {
+                            firstFailure = e;
+                        } else {
+                            firstFailure.addSuppressed(e); 
+                        }
+                        throw e; 
+                    } catch (Exception e) {
+                        if (firstFailure == null) {//Duplicate this code rather than use a finally block to avoid going into a finally block on every successful get
+                            firstFailure = e;
+                        } else {
+                            firstFailure.addSuppressed(e); 
+                        }
+                        throw new ConcurrentException(e); 
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Disposes the object wrapped by this instance if it has been created and closes
+     * this intializer.
+     *
+     * This method will only attempt to dispose an object if it has successfully been
+     * initialized. It will then close this LazyInitializerWithDisposer permemently 
+     * regardless of the state before the method was called, or any exceptions during
+     * disposal. Subsequent calls will have no effect.
+     *
+     * @return true if the object was successfully disposed, otherwise false
+     * @throws ConcurrentException if an error occurred during disposal of
+     * the object. The state will still be set to disposed.
+     */
+    public boolean dispose() throws ConcurrentException {
+        return disposeInternal(disposer);
+    }
+
+    /**
+     * Closes this initializer without disposing the wrapped object. This is equivalent
+     * to calling dispose() with a no-op consumer.
+     * 
+     * @return true if the object was previously created and not previously disposed, otherwise false
+     */
+    public boolean close() {
+        try {
+            return disposeInternal(ignored -> {});
+        } catch (ConcurrentException ignored) {//a no-op consumer will never throw anything.
+            return false;
+        }
+    }
+
+    private boolean disposeInternal(FailableConsumer<? super T, ? extends Exception> disposer) throws ConcurrentException {
+        T disposable = object;
+
+        if (disposable != DISPOSED) {
+            synchronized (NO_INIT) {
+                disposable = object;
+
+                if (disposable == DISPOSED) {
+                    return false;
+                }
+
+                if (disposable == NO_INIT) {
+                    object = (T) DISPOSED;
+                    return false;
+                }
+
+                try {
+                    object = (T) DISPOSED;
+                    disposer.accept(disposable);
+                    return true;
+                } catch (RuntimeException e) {//So it doesn't get wrapped in the next block.
+                    throw e; 
+                } catch (Exception e) {
+                    throw new ConcurrentException(e); 
+                } finally {
+                    this.initializer = null;
+                    this.disposer = null;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Acquire the object wrapped by this LazyInitializerWithDisposer but do not initialize it if it has not been initialized
+     * 
+     * @return An Optional that will contain the value produced by get(), or it will be empty if this LazyInitializerWithDisposer does not currently contain a wrapped object.
+     */
+    public Optional<T> peek() {
+        return Optional.ofNullable((T) object).filter(o -> ! (o == NO_INIT || o == DISPOSED));
+    }
+
+    /**
+     * @return true if the object was previously created, and the initializer has neither been closed or disposed, otherwise false.
+     */
+    public boolean isReady() {
+        return (! (object == NO_INIT || object == DISPOSED) );
+    }
+
+    /**
+     * @return true if initializer has been closed or disposed, otherwise false.
+     */
+    public boolean isDisposed() {
+        return object == DISPOSED;
+    }
+}

--- a/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerWithDisposerTest.java
+++ b/src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerWithDisposerTest.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3.concurrent;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeoutException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * Test class for {@code LazyInitializerWithDisposer}.
+ */
+public class LazyInitializerWithDisposerTest extends AbstractConcurrentInitializerTest {
+    /** The initializer to be tested. */
+    private LazyInitializerWithDisposer<StatefulObject> initializer;
+
+    @BeforeEach
+    public void setUp() {
+        initializer = new LazyInitializerWithDisposer<StatefulObject>(StatefulObject::new, StatefulObject::dispose);
+    }
+
+    /**
+     * Returns the initializer to be tested. This implementation returns the
+     * {@code LazyInitializer} created in the {@code setUp()} method.
+     *
+     * @return the initializer to be tested
+     */
+    @Override
+    protected ConcurrentInitializer<Object> createInitializer() {
+        return (ConcurrentInitializer) initializer;
+    }
+
+    @Test
+    public void testGet() throws ConcurrentException {
+        assertTrue(initializer.get().getClass().isAssignableFrom(StatefulObject.class));
+    }
+
+    @Test
+    public void testGetIfPossible() throws ConcurrentException {
+        Optional<StatefulObject> optionalStatefulObject = initializer.getIfPossible();
+        assertTrue(optionalStatefulObject.isPresent());
+        optionalStatefulObject.ifPresent((statefulObject) -> assertFalse(statefulObject.isDisposed()));
+
+        initializer.dispose();
+
+        assertTrue(optionalStatefulObject.isPresent());
+        optionalStatefulObject.ifPresent((statefulObject) -> assertTrue(statefulObject.isDisposed()));
+
+        Optional<StatefulObject> optionalStatefulObjectTwo = initializer.getIfPossible();
+        assertFalse(optionalStatefulObjectTwo.isPresent());
+    }
+
+    @Test
+    public void testSupplierOfNull() throws ConcurrentException {
+         LazyInitializerWithDisposer<StatefulObject> returnNullInitializer = new LazyInitializerWithDisposer<StatefulObject>(
+             () -> { 
+                 return null;
+             },
+             (statefulObject) -> {}
+         );
+
+         StatefulObject nullStatefulObject = returnNullInitializer.get();
+         assertNull(nullStatefulObject);
+
+         Optional<StatefulObject> optionalStatefulObject = returnNullInitializer.getIfPossible();
+         assertFalse(optionalStatefulObject.isPresent());     
+
+         Optional<StatefulObject> optionalStatefulObjectTwo = returnNullInitializer.peek();
+         assertFalse(optionalStatefulObjectTwo.isPresent());    
+    }
+
+    @Test
+    public void testDisposal() throws ConcurrentException {
+        StatefulObject statefulObject = initializer.get();
+        assertFalse(statefulObject.isDisposed());
+
+        assertTrue(initializer.dispose());
+        assertFalse(initializer.dispose());
+
+        assertTrue(statefulObject.isDisposed());
+
+        assertThrows(AlreadyDisposedException.class, initializer::get);        
+    }
+
+    @Test
+    public void testClose() throws ConcurrentException {
+        StatefulObject statefulObject = initializer.get();
+        assertFalse(statefulObject.isDisposed());
+
+        assertTrue(initializer.close());
+        assertFalse(initializer.close());
+
+        assertFalse(statefulObject.isDisposed());
+        assertFalse(initializer.dispose());
+        assertFalse(statefulObject.isDisposed());
+
+        assertThrows(AlreadyDisposedException.class, initializer::get);        
+    }
+
+    @Test
+    public void testPeek() throws ConcurrentException {
+
+        assertFalse(initializer.peek().isPresent());
+
+        initializer.get();
+        assertTrue(initializer.peek().isPresent());
+        assertEquals(initializer.get(), initializer.peek().get());
+
+        initializer.dispose();
+        assertFalse(initializer.peek().isPresent());
+    }
+
+    @Test
+    public void testBooleanGettersWithDispose() throws ConcurrentException {
+
+        assertFalse(initializer.isReady());
+        assertFalse(initializer.isDisposed());
+
+        initializer.get();
+
+        assertTrue(initializer.isReady());
+        assertFalse(initializer.isDisposed());
+
+        initializer.dispose();
+
+        assertFalse(initializer.isReady());
+        assertTrue(initializer.isDisposed());
+    }
+
+    @Test
+    public void testBooleanGettersWithClose() throws ConcurrentException {
+
+        assertFalse(initializer.isReady());
+        assertFalse(initializer.isDisposed());
+
+        initializer.get();
+
+        assertTrue(initializer.isReady());
+        assertFalse(initializer.isDisposed());
+
+        initializer.close();
+
+        assertFalse(initializer.isReady());
+        assertTrue(initializer.isDisposed());
+    }
+
+    //Tests exceptions are properly wrapped in a ConcurrentException, also tests we can handle lambdas and method signatures with multiple checked exceptions
+    @Test
+    public void testExceptionWrapping() throws ConcurrentException {
+         LazyInitializerWithDisposer<StatefulObjectWithCheckedExceptions> unreliableInitializer = new LazyInitializerWithDisposer<StatefulObjectWithCheckedExceptions>(
+             StatefulObjectWithCheckedExceptions::new,
+             (statefulObject) -> {
+                 String nonsense = "tea";
+                 if (nonsense.equals("tea")) {
+                     throw new IOException();
+                 }
+         });
+
+        assertThrows(ConcurrentException.class, unreliableInitializer::get);
+    }
+
+    @Test
+    public void testSuccessOnRetry() throws ConcurrentException {
+         final AtomicInteger tryCount = new AtomicInteger(0);//used for the convience of incrementAndGet
+
+         LazyInitializerWithDisposer<StatefulObject> unreliableInitializer = new LazyInitializerWithDisposer<StatefulObject>(
+             () -> { 
+                 if (tryCount.incrementAndGet() == 3) {
+                     return new StatefulObject();
+                 } else {
+                     throw new ConcurrentException();
+                 }
+             },
+             (statefulObject) -> {}
+         );
+
+        assertThrows(ConcurrentException.class, unreliableInitializer::get);
+        assertThrows(ConcurrentException.class, unreliableInitializer::get);
+
+        assertTrue(unreliableInitializer.get() instanceof StatefulObject);
+    }
+
+    @Test
+    public void testFailPreserved() throws ConcurrentException {
+         final AtomicInteger tryCount = new AtomicInteger(0);//used for the convience of incrementAndGet
+
+         LazyInitializerWithDisposer<StatefulObject> unreliableInitializer = new LazyInitializerWithDisposer<StatefulObject>(
+             () -> {
+                 if (tryCount.incrementAndGet() >= 3) {
+                     return new StatefulObject();
+                 } else {
+                     throw new ConcurrentException();
+                 }
+             },
+             (statefulObject) -> {},
+             2 //Allow two tries
+         );
+
+         //Don't use a for loop so the line number on a test failure is useful
+
+         assertThrows(ConcurrentException.class, unreliableInitializer::get);
+         assertThrows(ConcurrentException.class, unreliableInitializer::get);
+         assertThrows(ConcurrentException.class, unreliableInitializer::get);
+         assertThrows(ConcurrentException.class, unreliableInitializer::get);
+         assertThrows(ConcurrentException.class, unreliableInitializer::get);
+    }
+
+    @Test
+    public void testRuntimeException() throws ConcurrentException {
+         LazyInitializerWithDisposer<StatefulObject> runtimeExceptionInitializer = new LazyInitializerWithDisposer<StatefulObject>(
+             () -> {throw new RuntimeException("test exception");},
+             (statefulObject) -> {}
+         );
+
+         assertThrows(RuntimeException.class, runtimeExceptionInitializer::get);
+    }
+
+    @Test
+    public void testDisposeDuringGet() throws ConcurrentException {
+
+         //In this test we ensure that a dispose() called while get() is in progress:
+         //a) does not prevent get() returning an object.
+         //b) disposes of the object get acquires in step a
+         //Calling get() than dispose() a microsecond later should have the same behaviour
+         //as calling get() then dispose() an hour later. get() returns an object
+         //then dispose() disposes it.
+
+         //We can't actually ensure that disposed() has been called because if you call 
+         //dispose() while get() is running, it will wait for get() to finish beofore 
+         //invoking anything that can send a singal saying dispose has been invoked.
+
+         //Therefore we do the next best thing. We ensure that:
+         //1) We are inside the get() supplier on one thread.
+         //2) We are immediately prior to calling dispose() on another thread.
+         //Then we release thread two and sleep for a bit before releasing thread one.
+
+         final CountDownLatch holdUntilAfterGetCalled = new CountDownLatch(1);
+         final CountDownLatch holdUntilJustBeforeDisposedCalled = new CountDownLatch(1);
+         final CountDownLatch holdUntilAfterDisposedCalled = new CountDownLatch(1);
+         final CountDownLatch holdUntilAfterDisposedCompleted = new CountDownLatch(1);
+
+         final LazyInitializerWithDisposer<StatefulObject> slowInitializer = new LazyInitializerWithDisposer<StatefulObject>(
+             () -> {
+                 try {
+                     holdUntilAfterGetCalled.countDown();      
+                     holdUntilAfterDisposedCalled.await();             
+                 } catch (InterruptedException e) {
+                     fail(e);
+                 }
+                 return new StatefulObject();
+             },
+             (statefulObject) -> {
+                 statefulObject.dispose();
+                 holdUntilAfterDisposedCompleted.countDown();
+             }
+          );
+
+         //Step one: Call get()
+         ForkJoinPool.commonPool().execute(() -> {
+             try{
+                 StatefulObject statefulObject = slowInitializer.get();
+
+                 holdUntilAfterDisposedCompleted.await();
+                 assertTrue(statefulObject.isDisposed());
+             } catch(InterruptedException e) {
+                 fail(e);
+             } catch(ConcurrentException e) {
+                 fail(e);
+             }
+         });
+
+         //Step two: Wait until the get() method has started.
+         try {
+             holdUntilAfterGetCalled.await();
+         } catch(InterruptedException e) {
+             fail(e);
+         }
+         
+         //Step three: get call dispose()
+         ForkJoinPool.commonPool().execute(() -> {
+             try{
+                 holdUntilJustBeforeDisposedCalled.countDown();
+                 slowInitializer.dispose();
+             } catch(ConcurrentException e) {
+                 fail(e);
+             }
+         });
+
+         //Step four: Wait until the dispose() method is about to start.
+         try {
+             holdUntilJustBeforeDisposedCalled.await();
+         } catch(InterruptedException e) {
+             fail(e);
+         }
+
+         //Step five: Sleep to ensure we're actually in dispose()
+         try {
+             Thread.sleep(1000);
+         } catch(InterruptedException e) {
+             fail(e);
+         }
+
+         //Step six: Now that get() and dispose() should both be in progress, release get()
+         holdUntilAfterDisposedCalled.countDown();
+         
+         //Step seven takes place inside the thread that calls get(). dispose() will release 
+         //the last latch. Then the thread that calls get() will assert that the object is
+         //disposed 
+    }
+
+    /**
+     * A test object 
+     */
+    private static class StatefulObject {
+        private boolean disposed = false;
+
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }        
+    }
+
+    /**
+     * A test object with exceptions declared on the constructor
+     */
+    private static class StatefulObjectWithCheckedExceptions {
+        private boolean disposed = false;
+
+        public StatefulObjectWithCheckedExceptions() throws TimeoutException, IOException {
+            String nonsense = "hatter";
+
+            //String equality so the compiler can't tell if its always/never going to pass.
+            if (nonsense.equals("hatter")) {
+                throw new TimeoutException();
+            }
+            if (nonsense.equals("doormouse")) {
+                throw new IOException();
+            }
+        }
+
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }        
+    }
+}


### PR DESCRIPTION
This Pull Request creates a variant of LazyInitializer that also allows you to dispose of the wrapped object.

The use case is if you have an object that might or might not be needed; but if it is created it needs to be disposed. LazyInitalizer does not allow you to check if the wrapped object has been created, so the only way to dispose it is to call get() then a method on the acquired object. Creating the wrapped object just so you can dispose it defeats the point, so this new class allows for this use case.

Here are the design decisions I made, and the rationales for them: 

- Using FailableConsumer and FailableSupplier instead of making LazyInitializerWithDisposer an abstract class like LazyInitializer.
- - I think being able to create a new LazyInitializerWithDisposer in one line using Lambdas or `::` method reference operators provided enough of an advantage to justify using a different design to LazyInitializer.
- Not having any way to reset the object after calling `dispose()` or `close()`
- - I chose this because it makes it easier to reason about the lifecylce of a LazyInitializerWithDisposer. If you ever observe that it has been disposed you never have to worry about the possibility it will be reset else where. I thought this was more valuable than the ability to push a change in state to all objects with a reference to LazyInitializerWithDisposer.
- Using AlreadyDisposedException instead of ConcurrentException
- - Even though I'm not pleased with having the statement `throws ConcurrentException` refer to both AlreadyDisposedException and ConcurrentException I thought that it was useful enough to have separate catch blocks for when the Initalizer is disposed and when something goes wrong inside the supplier or consumer to justify this. 